### PR TITLE
Fixes notebook config location in bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -251,9 +251,10 @@ echo "export SPARK_CLASSPATH=" >> zeppelin/conf/zeppelin-env.sh
 
 # Jupyter server setup
 jupyter notebook --generate-config
-cp /home/vagrant/Agile_Data_Code_2/jupyter_notebook_config.py /home/vagrant/.jupyter/
-mkdir /home/vagrant/certs
-sudo openssl req -x509 -nodes -days 365 -newkey rsa:1024 -subj "/C=US" -keyout /home/vagrant/certs/mycert.pem -out /home/vagrant/certs/mycert.pem
+mkdir /root/.jupyter/
+cp /home/vagrant/Agile_Data_Code_2/jupyter_notebook_config.py /root/.jupyter/
+mkdir /root/certs
+sudo openssl req -x509 -nodes -days 365 -newkey rsa:1024 -subj "/C=US" -keyout /root/certs/mycert.pem -out /root/certs/mycert.pem
 
 jupyter notebook --ip=0.0.0.0 --allow-root --no-browser &
 


### PR DESCRIPTION
When the bootstrap script starts the notebook process, it is as root user. It looks for the config files in the root, not vagrant home.