### PR TITLE
fix obsolete Vagrant box search URL and box name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,12 +11,8 @@ Vagrant.configure("2") do |config|
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "precise64"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  # boxes at https://app.vagrantup.com/boxes/search
+  config.vm.box = "hashicorp/precise64"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
Attempts to run `vagrant up` results in a timeout when downloading the box file. 

```$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'precise64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'precise64' (v0) for provider: virtualbox
    default: Downloading: http://files.vagrantup.com/precise64.box
    default: Download redirected to host: hashicorp-files.hashicorp.com
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Failed to connect to hashicorp-files.hashicorp.com port 443: Operation timed out
```

This is because the name has been changed from `precise64` to `hashicorp/precise64`.  Also noticed that the URL for searching for boxes is not correct and updated that as well.