### PR TITLE
rewrite the instruction comment to provide better guidance

### DIFF
--- a/ch02/pyspark_mongodb.py
+++ b/ch02/pyspark_mongodb.py
@@ -1,7 +1,52 @@
-# Run me with:
+# This code sample is meant to be executed line-by-line in a 
+# pyspark session.
 #
-# PYSPARK_DRIVER_PYTHON=ipython pyspark --jars ../lib/mongo-hadoop-spark-1.5.1.jar,../lib/mongo-java-driver-3.2.2.jar,../lib/mongo-hadoop-1.5.1.jar \
-# --driver-class-path ../lib/mongo-hadoop-spark-1.5.1.jar:../lib/mongo-java-driver-3.2.2.jar:../lib/mongo-hadoop-1.5.1.jar
+# Prior to launching pyspark, run the following line in the 
+# shell where pyspark will be launched.
+#
+# export PYSPARK_DRIVER_PYTHON=ipython
+#
+# The pyspark launch command needs to have additional command line
+# arguments passed to ensure that Java classes used to connect to
+# MongoDB are found.
+#
+# The Java classes reside in JAR files that were
+# preinstalled via the boostrap.sh script and placed in the 
+# lib directory. You will need to note the version of the
+# libraries by inspecting the JAR filenames.  For example,
+# if running the following shell command:
+#
+# $ ls Agile_Data_Code_2/lib/mongo*.jar
+#
+# yields the following listing:
+#
+# Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar	    
+# Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar
+# Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar
+#
+# then the mongo-hadoop version would be 2.0.2, and the 
+# Mongo-Java version would be 3.4.2.  
+#
+# Choosing to set these versions as environment variables
+# will make the invocation of the command much less error
+# prone.
+#
+# MONGOHADOOP_VERSION=2.0.2
+# MONGOJAVA_VERSION=3.4.2
+#
+# The names of the JAR files can then be pieced together
+# from the version strings.
+#
+# MONGOHADOOPSPARK_JAR=./lib/mongo-hadoop-spark-$MONGOHADOOP_VERSION.jar
+# MONGOJAVADRIVER_JAR=./lib/mongo-java-driver-$MONGOJAVA_VERSION.jar
+# MONGOHADOOP_JAR=./lib/mongo-hadoop-$MONGOHADOOP_VERSION.jar 
+#
+# You can then launch the pyspark session using the following
+# shell command from the Agile_Data_Code_2 directory:
+#
+# pyspark \
+#   --jars $MONGOHADOOPSPARK_JAR,$MONGOJAVADRIVER_JAR,$MONGOHADOOP_JAR \
+#   --driver-class-path $MONGOHADOOPSPARK_JAR:$MONGOJAVADRIVER_JAR:$MONGOHADOOP_JAR
 
 import pymongo
 import pymongo_spark


### PR DESCRIPTION
This commit provides a major rewrite of the instruction
comment at the heading of pyspark_mongodb.py. There are
several issues with the original:

1) An environment variable assignment and the command
to launch pyspark are displayed on a single line with
continuation characters, which gives the false impression
that the environment variable is to be set to the whole
thing.

2) The paths to the JAR files are expressed relative
to the directory containing the script, which means
that the author presumes that pyspark is being launched
from that directory. This contradicts the guidance
provided in the subsection "Running the Code". Indeed
if one does the launch from the ch02 directory,
you will get a file-not-found error for the CSV
because the path is relative to the parent directory.

3) The JAR files have versions that may not match the
environment set up by the bootstrap.sh script.

4) It is not clear if this script is to be run standalone
or executed line-by-line in a pyspark session.

The rewrite of the comment provides more background,
alerting the user that the script is to be run in
a pyspark session.  The environment variable
assignment is separated from the pyspark launch
command. The reader is encouraged to check the
versions of the JAR files and then set the versions
in environment variables to reduce the chance of typos.
The reader is also advised that the script is to be run
in the top-level directory of the Git repository.