### PR TITLE
fix versions for spark jar path

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,7 +209,7 @@ curl -sLko lib/lzo-hadoop-1.0.5.jar http://central.maven.org/maven2/org/anarres/
 cd /home/vagrant
 
 # Set the spark.jars path
-echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.10-5.2.1.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
+echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.6.1.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.11-6.1.2.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
 
 #
 # Kafka install and setup


### PR DESCRIPTION
In the bootstrap.sh script, the following JAR file had changes
in the versions that are retrieved from the web.

mongo-java-driver (3.4.2 -> 3.6.1)
elasticsearch-spark (20_2.10-5.2.1 -> 20_2.11-6.1.2)

However, the echo command that writes JAR file names to
the spark configuration file still has the old versions.
This commit updates those to prevent exceptions being
thrown when pyspark is being launched.

Might be worth setting some variables in the script that
track what versions are being used so that having to
edit the script multiple places in the future is avoided.