### PR TITLE
Fix pyspark streaming py

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,7 +209,7 @@ curl -sLko lib/lzo-hadoop-1.0.5.jar http://central.maven.org/maven2/org/anarres/
 cd /home/vagrant
 
 # Set the spark.jars path
-echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.6.1.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.11-6.1.2.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
+echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.10-5.2.1.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
 
 #
 # Kafka install and setup

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,7 +209,7 @@ curl -sLko lib/lzo-hadoop-1.0.5.jar http://central.maven.org/maven2/org/anarres/
 cd /home/vagrant
 
 # Set the spark.jars path
-echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.10-5.2.1.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
+echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.6.1.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.11-6.1.2.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
 
 #
 # Kafka install and setup

--- a/ch02/pyspark_streaming.py
+++ b/ch02/pyspark_streaming.py
@@ -5,13 +5,17 @@ from pyspark import SparkContext, SparkConf
 from pyspark.streaming import StreamingContext
 from pyspark.streaming.kafka import KafkaUtils, OffsetRange, TopicAndPartition
 
+
 # Process data every 10 seconds
-PERIOD=10
-BROKERS='localhost:9092'
-TOPIC='test'
+PERIOD = 10
+BROKERS = 'localhost:9092'
+TOPIC = 'test'
 
 conf = SparkConf().set("spark.default.parallelism", 1)
-#sc = SparkContext(appName = "Agile Data Science: PySpark Streaming 'Hello, World!'", conf = conf)
+
+# Stop the default SparkContext before creating a new one.
+sc.stop()
+sc = SparkContext(appName="Agile Data Science: PySpark Streaming 'Hello, World!'", conf = conf)
 ssc = StreamingContext(sc, PERIOD)
 
 stream = KafkaUtils.createDirectStream(


### PR DESCRIPTION
fix script by adding call to stop default SparkContext

This commit fixes an error that is observed in the book version
of the code that occurs when a new SparkContext is created.

```
>>> sc = SparkContext(
... appName = "Agile Data Science: PySpark Streaming 'Hello, world!'", conf=conf
... )
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/home/vagrant/spark/python/pyspark/context.py", line 115, in __init__
SparkContext._ensure_initialized(self, gateway=gateway, conf=conf)
  File "/home/vagrant/spark/python/pyspark/context.py", line 299, in _ensure_initialized
callsite.function, callsite.file, callsite.linenum))
ValueError: Cannot run multiple SparkContexts at once; existing SparkContext(app=PySparkShell, master=local[*]) created by <module> at /home/vagrant/spark/python/pyspark/shell.py:45
```

This can be fixed by stopping the default SparkContext that is
created during startup.  This is proably a better fix than
just commenting out the instantiation of the SparkContext
because it ensures the SparkConf is used.