### PR TITLE
Add jupyter to vagrant ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,8 +49,9 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision :shell, :path => "bootstrap.sh"
 
-  # Map hosts ports 5000,4567,8080 to local port 5000,4567,8080
+  # Map hosts ports 5000,4567,8080, 8888 to local port 5000,4567,8080, 8888
   config.vm.network :forwarded_port, guest: 5000, host: 5000
   config.vm.network :forwarded_port, guest: 4567, host: 4567
   config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 8888, host: 8888
 end


### PR DESCRIPTION
Adding port 8888 to the list of mapped ports in the Vagrantfile ensures that one can access Jupyter on the virtual machine without having to create a forwarded port through an SSH connection.