### PR TITLE
fix bad versions for mongo-java-driver and elasticsearch-spark jars

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,7 +209,7 @@ curl -sLko lib/lzo-hadoop-1.0.5.jar http://central.maven.org/maven2/org/anarres/
 cd /home/vagrant
 
 # Set the spark.jars path
-echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.10-5.2.1.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
+echo "spark.jars /home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.6.1.jar,/home/vagrant/Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar,/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.11-6.1.2.jar,/home/vagrant/Agile_Data_Code_2/lib/snappy-java-1.1.7.1.jar,/home/vagrant/Agile_Data_Code_2/lib/lzo-hadoop-1.0.5.jar,/home/vagrant/Agile_Data_Code_2/lib/commons-httpclient-3.1.jar" | sudo tee -a /home/vagrant/spark/conf/spark-defaults.conf
 
 #
 # Kafka install and setup

--- a/ch02/pyspark_mongodb.py
+++ b/ch02/pyspark_mongodb.py
@@ -22,17 +22,17 @@
 #
 # Agile_Data_Code_2/lib/mongo-hadoop-2.0.2.jar	    
 # Agile_Data_Code_2/lib/mongo-hadoop-spark-2.0.2.jar
-# Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar
+# Agile_Data_Code_2/lib/mongo-java-driver-3.6.1.jar
 #
 # then the mongo-hadoop version would be 2.0.2, and the 
-# Mongo-Java version would be 3.4.2.  
+# Mongo-Java version would be 3.6.1.
 #
 # Choosing to set these versions as environment variables
 # will make the invocation of the command much less error
 # prone.
 #
 # MONGOHADOOP_VERSION=2.0.2
-# MONGOJAVA_VERSION=3.4.2
+# MONGOJAVA_VERSION=3.6.1
 #
 # The names of the JAR files can then be pieced together
 # from the version strings.
@@ -48,7 +48,6 @@
 #   --jars $MONGOHADOOPSPARK_JAR,$MONGOJAVADRIVER_JAR,$MONGOHADOOP_JAR \
 #   --driver-class-path $MONGOHADOOPSPARK_JAR:$MONGOJAVADRIVER_JAR:$MONGOHADOOP_JAR
 
-import pymongo
 import pymongo_spark
 # Important: activate pymongo_spark.
 pymongo_spark.activate()


### PR DESCRIPTION
This commit fixes a shell echo command that appends JAR paths to
the Apache Spark configuration file.  The ones for mongo-java-driver
and elasticsearch-spark do not match what are present in the lib
directory.

The effect of making this change means that the following errors (and their underlying exceptions) will be removed from the startup sequence for `pyspark`.

```
18/12/05 21:26:12 ERROR SparkContext: Failed to add file:/home/vagrant/Agile_Data_Code_2/lib/mongo-java-driver-3.4.2.jar to Spark environment

18/12/05 21:26:12 ERROR SparkContext: Failed to add file:/home/vagrant/Agile_Data_Code_2/lib/elasticsearch-spark-20_2.10-5.2.1.jar to Spark environment
```