### PR TITLE
Painless script with elastic search

### DIFF
--- a/painless script with elastic
+++ b/painless script with elastic
@@ -1,0 +1,25 @@
+curl -X POST   'http://localhost:9200/tweets/tweet/_search' -H 'Content-Type: application/json'   -d '{  
+  "query":{  
+     "bool":{  
+        "must":[  
+           {  
+              "match":{  
+                 "message":"painless"
+              }
+           }
+        ],
+        "filter":[  
+           {  
+              "script":{  
+                 "script":{  
+                    "inline":"doc['\''message.keyword'\''].value.length() > params.length",
+                    "params":{  
+                       "length":25
+                    }
+                 }
+              }
+           }
+        ]
+     }
+  }
+}'


### PR DESCRIPTION
Script query allows us to execute a script on each document. Script queries are usually used in filter context. When you want to have a script in the query or filter context, make sure you embed the script in a script object ( “script” :{}). Hence in the below example you would see script tag within a script tag.  

Let’s try it out with an example. Let’s find out all the tweets that contains string “painless” and has a length greater than 25 characters.