### PR TITLE
Abort install if awscli is not installed

### DIFF
--- a/ec2.sh
+++ b/ec2.sh
@@ -31,6 +31,10 @@ if [ -z `which jq` ]; then
   exit
 fi
 
+if [ -z `which aws`]; then
+    echo "You need to install the aws CLI tool. Go here for installation instructions https://aws.amazon.com/cli/" | tee -a $LOG_FILE
+    exit 1
+
 echo "Testing for security group 'agile_data_science' ..." | tee -a $LOG_FILE
 GROUP_NAME_FILTER=`aws ec2 describe-security-groups | jq '.SecurityGroups[] | select(.GroupName == "agile_data_science") | length'`
 


### PR DESCRIPTION
Hi Russell! Thanks for writing this book. I stumbled across a UX issue with the ec2.sh script. If you dont have awscli installed locally then the script spits out a bunch of "aws: command not found". It would likely be a better experience if the script fails and directs the user to a page with installation instructions. Even better would be to write an "install-aws.sh" script, but that's beyond the scope of what I have time for. 

This is the partial log output that I see if I dont have awscli installed:

```
Testing for security group 'agile_data_science' ...
ec2.sh: line 35: aws: command not found
Security group 'agile_data_science' not present ...
Creating security group 'agile_data_science' ...
ec2.sh: line 41: aws: command not found

Detecting external IP address ...
Authorizing port 22 to your external IP (174.99.125.239) in security group 'agile_data_science' ...
ec2.sh: line 54: aws: command not found

Testing for existence of keypair 'agile_data_science' and key 'agile_data_science.pem' ...
ec2.sh: line 61: aws: command not found
Key pair 'agile_data_science' not found ...
Generating keypair called 'agile_data_science' ...
ec2.sh: line 71: aws: command not found
Changing permissions of 'agile_data_science.pem' to 0600 ...

Detecting the default region...
ec2.sh: line 78: aws: command not found
The default region is ''
Determining the image ID to use according to region...
The image for region '' is '' ...

Initializing EBS optimized r4.xlarge EC2 instance in region '' with security group 'agile_data_science', key name 'agile_data_science' and image id '' using the script 'aws/ec2_bootstrap.sh'
ec2.sh: line 122: aws: command not found
Got reservation ID '' ...

Sleeping 10 seconds before inquiring to get the public hostname of the instance we just created ...
...
Awake!

Using the reservation ID to get the public hostname ...
ec2.sh: line 145: aws: command not found
The public hostname of the instance we just created is '' ...
Writing hostname to '.ec2_hostname' ...

Now we will tag this ec2 instance and name it 'agile_data_science_ec2' ...
ec2.sh: line 153: aws: command not found
ec2.sh: line 154: aws: command not found

After a few minutes (for it to initialize), you may ssh to this machine via the command in red:
ssh -i ./agile_data_science.pem ubuntu@
Note: only your IP of '174.99.125.239' is authorized to connect to this machine.

NOTE: IT WILL TAKE SEVERAL MINUTES FOR THIS MACHINE TO INITIALIZE. PLEASE WAIT FIVE MINUTES BEFORE LOGGING IN.

Note: if you ssh to this machine after a few minutes and there is no software in $HOME, please wait a few minutes for the install to finish.

Once you ssh in, the exercise code is in the Agile_Data_Code_2 directory! Run all files from this directory, with the exception of the web applications, which you will run from ex. ch08/web

Note: after a few minutes, now you will need to run ./ec2_create_tunnel.sh to forward ports 5000 and 8888 on the ec2 instance to your local ports 5000 and 8888. This way you can run the example web applications on the ec2 instance and browse them at http://localhost:5000 and you can view Jupyter notebooks at http://localhost:8888
If you tire of the ssh tunnel port forwarding, you may end these connections by executing ./ec2_kill_tunnel.sh

---------------------------------------------------------------------------------------------------------------------

Thanks for trying Agile Data Science 2.0!

If you have ANY problems, please file an issue on Github at https://github.com/rjurney/Agile_Data_Code_2/issues and I will resolve them.

If you need help creating your own applications, or with on-site or video training...
Check out Data Syndrome at http://datasyndrome.com

Enjoy! Russell Jurney <@rjurney> <russell.jurney@gmail.com> <http://linkedin.com/in/russelljurney>
```