### PR TITLE
Update macros.jnj

### DIFF
--- a/ch04/web/templates/macros.jnj
+++ b/ch04/web/templates/macros.jnj
@@ -14,3 +14,4 @@
       {% endif %}
     {% endfor -%}
   </div>
+{%- endmacro %}


### PR DESCRIPTION
Fixes following: "jinja2.exceptions.TemplateSyntaxError: Unexpected end of template. Jinja was looking for the following tags: 'endmacro'. The innermost block that needs to be closed is 'macro'."