### PR TITLE
Update bootstrap.sh to install openjdk8

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,21 +13,32 @@ sudo apt-get install -y zip unzip curl bzip2 python-dev build-essential git libs
 #
 # Install Java and setup ENV
 #
-sudo add-apt-repository -y ppa:webupd8team/java
+#
+# Uncomment below to install Oracle Java8 (No longer available from ppa)
+#
+#sudo add-apt-repository -y ppa:webupd8team/java
+#sudo apt-get update
+#echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
+#sudo apt-get install -y oracle-java8-installer oracle-java8-set-default
+#cd /var/lib/dpkg/info
+#sudo sed -i 's|JAVA_VERSION=8u151|JAVA_VERSION=8u162|' oracle-java8-installer.*
+#sudo sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/|' oracle-java8-installer.*
+#sudo sed -i 's|SHA256SUM_TGZ="c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"|SHA256SUM_TGZ="68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"|' oracle-java8-installer.*
+#sudo sed -i 's|J_DIR=jdk1.8.0_151|J_DIR=jdk1.8.0_162|' oracle-java8-installer.*
+#echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
+#sudo apt-get install -y oracle-java8-installer oracle-java8-set-default
+#
+#export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+#echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" | sudo tee -a /home/vagrant/.bash_profile
+#
+# Uncomment below to install openjdk verion of java
+#
+sudo add-apt-repository ppa:openjdk-r/ppa
 sudo apt-get update
-echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
-sudo apt-get install -y oracle-java8-installer oracle-java8-set-default
-cd /var/lib/dpkg/info
-sudo sed -i 's|JAVA_VERSION=8u151|JAVA_VERSION=8u162|' oracle-java8-installer.*
-sudo sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/|' oracle-java8-installer.*
-sudo sed -i 's|SHA256SUM_TGZ="c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"|SHA256SUM_TGZ="68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"|' oracle-java8-installer.*
-sudo sed -i 's|J_DIR=jdk1.8.0_151|J_DIR=jdk1.8.0_162|' oracle-java8-installer.*
-echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
-sudo apt-get install -y oracle-java8-installer oracle-java8-set-default
+sudo apt-get install openjdk-8-jdk
 
-
-export JAVA_HOME=/usr/lib/jvm/java-8-oracle
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" | sudo tee -a /home/vagrant/.bash_profile
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" | sudo tee -a /home/vagrant/.bash_profile
 
 #
 # Install Miniconda


### PR DESCRIPTION
Updated the bootstrap.sh script to install the openjdk8 version of java and export the JAVA_HOME variable accordingly . Oracle Java8 is no longer available from the webupd8team ppa.

I've only used this with Vagrant, but I would assume the ec2_bootstrap.sh could be modified similarly.