### PR TITLE
uncomment jupyter server setup

### DIFF
--- a/aws/ec2_bootstrap.sh
+++ b/aws/ec2_bootstrap.sh
@@ -329,13 +329,13 @@ echo "sudo chown -R ubuntu /home/ubuntu/airflow" | sudo tee -a /home/ubuntu/.bas
 echo "sudo chgrp -R ubuntu /home/ubuntu/airflow" | sudo tee -a /home/ubuntu/.bash_profile
 
 # Jupyter server setup
-# echo "" | tee -a $LOG_FILE
-# echo "Starting Jupyter notebook server ..." | tee -a $LOG_FILE
-# jupyter-notebook --generate-config
-# cp /home/ubuntu/Agile_Data_Code_2/jupyter_notebook_config.py /home/ubuntu/.jupyter/
-# cd /home/ubuntu/Agile_Data_Code_2
-# jupyter-notebook --ip=0.0.0.0 &
-# cd
+echo "" | tee -a $LOG_FILE
+echo "Starting Jupyter notebook server ..." | tee -a $LOG_FILE
+jupyter-notebook --generate-config
+cp /home/ubuntu/Agile_Data_Code_2/jupyter_notebook_config.py /home/ubuntu/.jupyter/
+cd /home/ubuntu/Agile_Data_Code_2
+jupyter-notebook --ip=0.0.0.0 &
+cd
 
 # Install Ant to build Cassandra
 sudo apt-get install -y ant


### PR DESCRIPTION
so as to indeed have jupyter notebook available at http://localhost:8888 as explained in "EC2 environment setup" part of book

"You will need to run Jupyter Notebooks from the root directory of the project, Agile_Data_Code_2. If you are using the Vagrant or EC2 setup, this has already been done for you in the boot script, and you can connect to Jupyter Notebooks at http://localhost:8888."

(I lost some time troubleshooting 8888 port forwarding when... notebook server just wasn't up)